### PR TITLE
Fix path to CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
           PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'CLA/signatures/v1.0/cla.json'
-          path-to-document: 'https://github.com/corgibytes/freshli/blob/main/CLA/CLA-v1.0.md'
+          path-to-document: 'https://github.com/corgibytes/freshli-lib/blob/main/CLA/CLA-v1.0.md'
           branch: 'main'
           allowlist: dependabot[bot]
 


### PR DESCRIPTION
The CLA bot currently uses an incorrect URL for the CLA. Contributors can't agree to it if they can't find it. :)